### PR TITLE
Fix HotA balance compatibility mod dependency

### DIFF
--- a/Mods/hota-balance-compatibility-patch/mod.json
+++ b/Mods/hota-balance-compatibility-patch/mod.json
@@ -14,6 +14,7 @@
 	"keepDisabled" : true,
 	"depends" :
 	[
+		"tides-of-war.alternative-creatures",
 		"hota.confluxvaultofashes"
 	],
 	"factions" :


### PR DESCRIPTION
ix HotA balance compatibility mod dependency on alternative-creatures submod.