### PR TITLE
Make Phantom Ship spawn only on water in random maps

### DIFF
--- a/Mods/banks/content/config/banks/phantomShip.json
+++ b/Mods/banks/content/config/banks/phantomShip.json
@@ -3,7 +3,7 @@
 	{
 		"types" :
 		{
-			"mdtDreadSkipperBank" :
+			"mdtDreadSkipperBankWater" :
 			{
 				"name" : "Phantom Ship",
 				"templates" : {
@@ -12,18 +12,219 @@
 						"visitableFrom" : [ "+++", "+++", "+++" ],
 						"mask" : [ "VVV", "VVV", "VVV", "VAB"],
 						"allowedTerrains" : [ "water" ]
-					},
-					"landShip" : {
-						"animation" : "banks/Shpair",
-						"visitableFrom" : [ "+++", "+++", "+++" ],
-						"mask" : [ "VVVV", "VVVV", "VVVA" ]
-//						"allowedTerrains" : [ "rough", "dirt", "swamp" ]
 					}
 				},
 				"rmg" : {
 					"value" : 2500,
 					"rarity" : 100,
 					"mapLimit" : 8
+				},
+				"levels" : [
+					{
+						"chance" : 20,
+						"guards" : [
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" },
+							{ "amount" : 2, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 500,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 2500
+							},
+							"creatures" :
+							[
+								{ "amount" : 4, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 20,
+						"guards" : [
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" },
+							{ "amount" : 4, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 800,
+							"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 3500
+							},
+							"creatures" :
+							[
+								{ "amount" : 6, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 20,
+						"guards" : [
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" },
+							{ "amount" : 6, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 9000,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 4500
+							},
+							"creatures" :
+							[
+								{ "amount" : 8, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					
+					{
+						"chance" : 15,
+						"guards" : [
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" },
+							{ "amount" : 8, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 10000,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 5500
+							},
+							"creatures" :
+							[
+								{ "amount" : 10, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 10,
+						"guards" : [
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" },
+							{ "amount" : 10, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 10000,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 6500
+							},
+							"creatures" :
+							[
+								{ "amount" : 12, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 5,
+						"guards" : [
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" },
+							{ "amount" : 12, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 12000,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 7500
+							},
+							"creatures" :
+							[
+								{ "amount" : 14, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 5,
+						"guards" : [
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" },
+							{ "amount" : 14, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 15000,
+						"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 8500
+							},
+							"creatures" :
+							[
+								{ "amount" : 16, "type" : "mdtDreadSkipper" }
+							]
+						}
+					},
+					{
+						"chance" : 5,
+						"guards" : [
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" },
+							{ "amount" : 18, "type" : "mdtDreadSkipper" }
+						],
+						"combat_value" : 20000,
+							"reward" : {
+							"value" : 10000,
+							"resources" :
+							{
+								"gold" : 9500
+							},
+							"creatures" :
+							[
+								{ "amount" : 20, "type" : "mdtDreadSkipper" }
+							]
+						}
+					}
+				]
+			},
+			"mdtDreadSkipperBankLand" :
+			{
+				"name" : "Phantom Ship",
+				"templates" : {
+					"landShip" : {
+						"animation" : "banks/Shpair",
+						"visitableFrom" : [ "+++", "+++", "+++" ],
+						"mask" : [ "VVVV", "VVVV", "VVVA" ]
+//						"allowedTerrains" : [ "rough", "dirt", "swamp" ]
+					}
 				},
 				"levels" : [
 					{

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 	"contact" : "http://www.forum.acidcave.net/topic.php?TID=1423",
 	"licenseName" : "Creative Commons Attribution-ShareAlike",
 	"licenseURL" : "http://creativecommons.org/licenses/by-sa/4.0/deed",
-	"version" : "1.0.13",
+	"version" : "1.0.14",
 	"downloadSize" : 28.4,
 	"compatibility" :
 	{
@@ -14,6 +14,7 @@
 	},
 	"changelog" :
 	{
+		"1.0.14"   : [ "Phantom Ship won't spawn on land in random maps" ],
 		"1.0.13"   : [ "Fixed possible crash on using creature banks in random maps" ],
 		"1.0.12"   : [ "Added the creatures' stackExp, fixed the translations and other bugs" ],
 		"1.0.11"   : [ "Updated chinese translation by Rindlit" ],


### PR DESCRIPTION
Actually I'm not sure if duplicating object only to change RMG settings is desired solution, but for now that's the best I know.