### PR TITLE
Daxaroth no longer "special"

### DIFF
--- a/Mods/heroes/content/config/heroes/dungeon/daxaroth.json
+++ b/Mods/heroes/content/config/heroes/dungeon/daxaroth.json
@@ -3,7 +3,7 @@
 	{
 		"class" : "overlord",
 		"female" : false,
-		"special" : true,
+		"special" : false,
 		"images" : {
 			"specialtySmall" : "heroes/dungeon/daxaroth_spec-small",
 			"specialtyLarge" : "heroes/dungeon/daxaroth_spec-large",


### PR DESCRIPTION
Kind of pointless keeping heroes like this "special" and not being known about, let alone played with